### PR TITLE
Update _estimation.py

### DIFF
--- a/toto/plugins/extreme/_estimation.py
+++ b/toto/plugins/extreme/_estimation.py
@@ -11,7 +11,10 @@ import warnings
 import scipy.stats as ss
 from scipy.stats._distn_infrastructure import rv_frozen as _rv_frozen
 from scipy import special
-from scipy.linalg import pinv2
+try : 
+    from scipy.linalg import pinv2
+except:
+    from scipy.linalg import pinv
 from scipy import optimize
 from scipy.special import expm1  # pylint: disable=no-name-in-module
 import numpy as np


### PR DESCRIPTION
scipy.linalg.pinv2 was deprecated with version 1.7 and removed with version 1.9. The functionality has been subsumed by scipy.linalg.pinv.